### PR TITLE
quickpars: Initial working version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,11 +13,26 @@ name = "jacc"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "quickpars",
 ]
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "quickpars"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "leb128",
+ "smallvec",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,5 @@
 [workspace]
-members = [
-  "crates/quickpars",
-  "crates/jacc"
-]
+members = ["crates/quickpars", "crates/jacc"]
 
 resolver = "2"
 
@@ -14,6 +11,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 
 [workspace.dependencies]
 anyhow = "1.0"
+smallvec = "1.13.1"
 
 [profile.release]
 lto = true

--- a/crates/jacc/Cargo.toml
+++ b/crates/jacc/Cargo.toml
@@ -7,3 +7,4 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+quickpars = { path = "../quickpars" }

--- a/crates/jacc/src/lib.rs
+++ b/crates/jacc/src/lib.rs
@@ -1,23 +1,44 @@
 //! JAC - The Javy Ahead-of-Time Compiler.
+use anyhow::Result;
+use quickpars::{Parser, Payload};
 
 // NOTE:
-// * `JS_EvalFunction` -> to evaluate the value as a function.
-//   The function evaluation, when the `JS_EVAL_FLAG_COMPILE_ONLY` is set, it
-//   returns a value tagged with `JS_TAG_FUNCTION_BYTECODE`. It also returns the
-//   bytecode instead of evaluating the function inline.
+// * `JS_EvalFunction` -> to evaluate the value as a function. The function
+// evaluation, when the `JS_EVAL_FLAG_COMPILE_ONLY` is set, it returns a value
+// tagged with `JS_TAG_FUNCTION_BYTECODE`. It also returns the bytecode instead
+// of evaluating the function inline.
 //
 //   Note that when writing the final bytecode object, `JS_TAG_FUNCTION_BYTECOE`
 //   gets transformed to `BC_TAG_FUNCTION_BYTECODE`, which is what gets used
 //   when reading the bytedode (see below).
 //
-// * After gathering the bytecode, we use `JS_ReadObject` to read the bytecode as `JSValue`.
+// * After gathering the bytecode, we use `JS_ReadObject` to read the bytecode
+// as `JSValue. This is like the process of instantiation.
 //   The sequence (incomplete at least right now), is:
 //   * `JS_ReadObjectAtoms`
 //   * `JS_ReadObjectRec`
 //   * `JS_ReadFunctionTag` (setup locals, etc)
 //      * `JS_ReadFunctionBytecode` (setup more atoms?)
 
-/// Compile QuickJS bytecode ahead-of-time to WebAssembly.
-pub fn compile(bytes: &[u8]) -> Vec<u8> {
-    vec![]
+// For the compiler to cooperate with the runtime, multiple things need to
+// happen:
+//
+// 1. At runtime, we still need to go through `JS_ReadObject` to "instantiate"
+//    the current object through bytecode. This will intern atoms and prepare
+//    a bunch of state.
+// 2. At compile time, we don't need to process the entire bytecode: assuming
+//    that at runtime we'll go through `JS_ReadObject`, we can "skip" to the
+//    function section.
+// 3. The driver: with this approach the current dynamically linked module, will
+//    be replaced by the code that we'll generate via LLVM. This code will
+//    contain some code to decide which functions we need to invoke, depending
+//    if we have a compiled version or not present.
+
+/// Main entry point to compile QuickJS bytecode ahead-of-time to WebAssembly.
+pub fn compile(bytes: &[u8]) -> Result<Vec<u8>> {
+    for payload in Parser::new().parse_buffer(bytes) {
+        dbg!(payload?);
+    }
+
+    Ok(vec![])
 }

--- a/crates/quickpars/Cargo.toml
+++ b/crates/quickpars/Cargo.toml
@@ -7,3 +7,5 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+smallvec = { workspace = true }
+leb128 = "0.2.5"

--- a/crates/quickpars/src/bc.rs
+++ b/crates/quickpars/src/bc.rs
@@ -1,0 +1,68 @@
+//! QuickJS bytecode details.
+
+use anyhow::{bail, ensure, Result};
+
+// QuickJS manages several flavors of bytecode version, depending on what
+// features the engine is compiled with. For the time being we assume `2`, which
+// means that the engine is compiled with BIGNUM support.
+pub const VERSION: u8 = 2;
+
+/// Bytecode tags.
+///
+/// Each tag represents a value or a section in the bytecode.
+#[derive(Debug)]
+pub enum Tag {
+    Null = 1,
+    Undefined,
+    False,
+    True,
+    I32,
+    F64,
+    String,
+    Object,
+    Array,
+    BigInt,
+    BigFloat,
+    BigDecimal,
+    TemplateObject,
+    FunctionBytecode,
+    Module,
+    TypedArray,
+    ArrayBuffer,
+    SharedArrayBuffer,
+    Date,
+    ObjectValue,
+    ObjectRef,
+}
+
+impl Tag {
+    /// Maps an arbitrary byte to a [Tag].
+    pub fn map_byte(byte: u8) -> Result<Tag> {
+        Ok(match byte {
+            14 => Tag::FunctionBytecode,
+            15 => Tag::Module,
+            _ => bail!("Unknown tag: {byte}"),
+        })
+    }
+}
+
+/// Extract the flag at the given index of the bitset.
+///
+/// #Safety
+///
+/// `T` should only be a primitive type.
+/// TODO: Find a way to restrict this.
+pub(crate) fn flag<T>(flags: u32, index: u32) -> u32 {
+    let size = std::mem::size_of::<T>();
+    (flags >> index) & ((1u32 << size) - 1)
+}
+
+/// Validates the bytecode version.
+pub(crate) fn validate_version(version: u8) -> Result<u8> {
+    let bc_version = VERSION;
+    ensure!(
+        version == bc_version,
+        "Mismatched bytecode version. Found: {version}, expected: {bc_version}"
+    );
+    Ok(version)
+}

--- a/crates/quickpars/src/lib.rs
+++ b/crates/quickpars/src/lib.rs
@@ -1,24 +1,311 @@
+//! QuickJS Bytecode Parser written in Rust.
+
+use anyhow::{anyhow, Context, Result};
+
+mod bc;
+mod readers;
+mod sections;
+use bc::{flag, validate_version, Tag};
+
+use readers::{read_str_bytes, slice, BinaryReader};
+use sections::{DebugInfo, FunctionSection, FunctionSectionHeader, HeaderSection, ModuleSection};
+
 /// Known payload in the bytecode.
-pub enum Payload {
-    Any,
+#[derive(Debug, Copy, Clone)]
+pub enum Payload<'a> {
+    Version(u8),
+    Header(HeaderSection<'a>),
+    Module(ModuleSection<'a>),
+    Function(FunctionSection<'a>),
+    End,
 }
 
-/// The current position of the parser.
-#[derive(Default)]
-pub struct Offset(u64);
-
-pub trait Handler {
-    type Output;
-    fn handle(payload: &Payload, offset: Offset) -> Self::Output;
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub(crate) enum ParserState {
+    Version,
+    Header,
+    Tags,
+    End,
 }
 
 /// A QuickJS bytecode parser.
-#[derive(Default)]
+#[derive(Debug, Copy, Clone)]
 pub struct Parser {
+    /// The state of the parser.
+    state: ParserState,
     /// The current position of the parser.
-    offset: Offset,
+    offset: usize,
+    /// Is the parser done.
+    done: bool,
 }
 
 impl Parser {
-    pub fn parse_all(&mut self, handler: impl Handler) {}
+    /// Create a new [Parser].
+    pub fn new() -> Self {
+        Self {
+            state: ParserState::Version,
+            offset: 0,
+            done: false,
+        }
+    }
+}
+
+impl Parser {
+    /// Parse the entire bytecode buffer.
+    pub fn parse_buffer<'a>(self, data: &'a [u8]) -> impl Iterator<Item = Result<Payload<'a>>> {
+        let mut parser = self;
+        std::iter::from_fn(move || {
+            if parser.done {
+                return None;
+            }
+            Some(parser.parse(data))
+        })
+    }
+
+    fn parse<'a>(&mut self, data: &'a [u8]) -> Result<Payload<'a>> {
+        // Every time `parse` is called, make sure to update the view of data
+        // that we're parsing via `&data[self.offset...]`
+        let mut reader = BinaryReader::with_initial_offset(&data[self.offset..], self.offset);
+        match self.parse_with(&mut reader) {
+            Ok(payload) => {
+                self.offset += reader.offset;
+                if self.offset >= data.len() {
+                    self.done = true;
+                }
+                Ok(payload)
+            }
+            Err(err) => {
+                self.done = true;
+                Err(err).with_context(|| {
+                    format!(
+                        "Failed to parse bytecode at offset: {} and state: {:?}",
+                        self.offset + reader.offset,
+                        self.state,
+                    )
+                })
+            }
+        }
+    }
+
+    fn parse_with<'a: 'b, 'b>(&mut self, reader: &'b mut BinaryReader<'a>) -> Result<Payload<'a>> {
+        use Payload::*;
+
+        let data = reader.data();
+        match self.state {
+            ParserState::Version => reader
+                .read_u8()
+                .and_then(validate_version)
+                .map(Version)
+                .and_then(|v| {
+                    self.state = ParserState::Header;
+                    Ok(v)
+                }),
+
+            ParserState::Header => {
+                let atom_count = reader.read_leb128()?;
+                self.compute_atoms_size(atom_count, &data[reader.offset..])
+                    .and_then(|size| slice(reader, size))
+                    .map(|section_reader| {
+                        self.state = ParserState::Tags;
+                        Header(HeaderSection::new(atom_count, section_reader))
+                    })
+            }
+            ParserState::Tags => reader
+                .read_u8()
+                .and_then(Tag::map_byte)
+                .and_then(|tag| self.parse_tag(tag, reader)),
+            ParserState::End => {
+                self.done = true;
+                Ok(End)
+            }
+        }
+    }
+
+    fn parse_tag<'a: 'b, 'b>(
+        &mut self,
+        tag: Tag,
+        reader: &'b mut BinaryReader<'a>,
+    ) -> Result<Payload<'a>> {
+        use Payload::*;
+
+        let data = reader.data();
+        match tag {
+            Tag::Module => {
+                let name_index = reader.read_leb128()?;
+                self.compute_module_section_size(&data[reader.offset..])
+                    .and_then(|size| slice(reader, size))
+                    .map(|section_reader| Module(ModuleSection::new(name_index, section_reader)))
+            }
+            Tag::FunctionBytecode => {
+                let flags = reader.read_u16()?;
+                // JS mode.
+                // Unsure what this is for.
+                reader.read_u8()?;
+                let name_index = reader.read_leb128()?;
+                let arg_count = reader.read_leb128()?;
+                let var_count = reader.read_leb128()?;
+                let defined_arg_count = reader.read_leb128()?;
+                let stack_size = reader.read_leb128()?;
+                let closure_count = reader.read_leb128()?;
+                let constant_pool_size = reader.read_leb128()?;
+                let bytecode_len = reader.read_leb128()?;
+                let local_count = reader.read_leb128()?;
+
+                let header = FunctionSectionHeader {
+                    flags,
+                    name_index,
+                    arg_count,
+                    var_count,
+                    defined_arg_count,
+                    stack_size,
+                    closure_count,
+                    constant_pool_size,
+                    bytecode_len,
+                    local_count,
+                };
+
+                let debug = flag::<bool>(flags as u32, 9);
+
+                let locals_reader = self
+                    .compute_locals_size(local_count, &data[reader.offset..])
+                    .and_then(|size| slice(reader, size))?;
+                let closures_reader = self
+                    .compute_closure_size(closure_count, &data[reader.offset..])
+                    .and_then(|size| slice(reader, size))?;
+                let operators_reader = slice(reader, bytecode_len as usize)?;
+
+                let debug_info = if debug != 0 {
+                    let filename = reader.read_leb128()?;
+                    let lineno = reader.read_leb128()?;
+                    let len = reader.read_leb128()?;
+
+                    let buffer = slice(reader, len as usize)?;
+                    Some(DebugInfo::new(filename, lineno, buffer))
+                } else {
+                    None
+                };
+
+                // Constants contain other bytecode functions.
+                if constant_pool_size == 0 {
+                    self.state = ParserState::End;
+                }
+
+                Ok(Function(FunctionSection::new(
+                    header,
+                    locals_reader,
+                    closures_reader,
+                    operators_reader,
+                    debug_info,
+                )))
+            }
+            x => Err(anyhow!("Unsupported {x:?}")),
+        }
+    }
+
+    /// Calculates the amount of bytes used for the interned atoms.
+    fn compute_atoms_size(&self, atom_count: u32, data: &[u8]) -> Result<usize> {
+        // Create a fresh new reader to make sure that we have the right information
+        // regarding the bytes consumed.
+        let mut reader = BinaryReader::with_initial_offset(data, self.offset);
+        (0..atom_count)
+            .try_for_each(|_| {
+                read_str_bytes(&mut reader)?;
+                Ok(())
+            })
+            .map(|_| reader.offset)
+    }
+
+    /// Computes the amount of bytes needed to encode the module section.
+    fn compute_module_section_size(&self, data: &[u8]) -> Result<usize> {
+        let mut reader = BinaryReader::with_initial_offset(data, self.offset);
+        reader
+            // Req module entries count.
+            .read_leb128()
+            // Each dependency.
+            .and_then(|deps| self.readn_leb128(deps as usize, &mut reader))
+            // Exports count.
+            .and_then(|_| reader.read_leb128())
+            // Each export.
+            .and_then(|exports| {
+                (0..exports).try_for_each(|_| {
+                    let export_type = reader.read_u8()?;
+                    // FIXME: Put in a constant.
+                    // 0 = local export.
+                    // TODO: Verify the following if/else.
+                    if export_type == 0 {
+                        // The local index of the export.
+                        reader.read_leb128()?;
+                    } else {
+                        // The index of the require module.
+                        reader.read_leb128()?;
+                        // The index of the name of the required module.
+                        reader.read_leb128()?;
+                    }
+                    // The export name.
+                    reader.read_leb128()?;
+                    Ok(())
+                })
+            })
+            // Star exports count.
+            .and_then(|_| reader.read_leb128())
+            // Each * export
+            .and_then(|star_exports| self.readn_leb128(star_exports as usize, &mut reader))
+            // Imports count.
+            .and_then(|_| reader.read_leb128())
+            // Each import.
+            .and_then(|imports_count| {
+                (0..imports_count).try_for_each(|_| {
+                    // Variable index.
+                    reader.read_leb128()?;
+                    // Import name index;
+                    reader.read_leb128()?;
+                    // Required module index.
+                    reader.read_leb128()?;
+
+                    Ok(())
+                })
+            })
+            // Return the reader offset.
+            .map(|_| reader.offset)
+    }
+
+    fn compute_locals_size(&self, locals_count: u32, data: &[u8]) -> Result<usize> {
+        let mut reader = BinaryReader::with_initial_offset(data, self.offset);
+        (0..locals_count)
+            .try_for_each(|_| {
+                // Var name.
+                reader.read_leb128()?;
+                // Scope level.
+                reader.read_leb128()?;
+                // Scope next.
+                reader.read_leb128()?;
+                // Flags.
+                reader.read_u8()?;
+                Ok(())
+            })
+            .map(|_| reader.offset)
+    }
+
+    fn compute_closure_size(&self, closure_count: u32, data: &[u8]) -> Result<usize> {
+        let mut reader = BinaryReader::with_initial_offset(data, self.offset);
+        (0..closure_count)
+            .try_for_each(|_| {
+                // Var name.
+                reader.read_leb128()?;
+                // Index.
+                reader.read_leb128()?;
+                // Flags.
+                reader.read_u8()?;
+                Ok(())
+            })
+            .map(|_| reader.offset)
+    }
+
+    /// Reads `n` leb128 encodings.
+    fn readn_leb128(&self, n: usize, reader: &mut BinaryReader<'_>) -> Result<()> {
+        (0..n).try_for_each(|_| {
+            reader.read_leb128()?;
+            Ok(())
+        })
+    }
 }

--- a/crates/quickpars/src/readers.rs
+++ b/crates/quickpars/src/readers.rs
@@ -1,0 +1,124 @@
+//! Bytecode reader.
+
+use anyhow::{ensure, Result};
+use std::io::Cursor;
+
+/// A general binary reader.
+#[derive(Debug, Copy, Clone)]
+pub struct BinaryReader<'a> {
+    /// A reference to the data that the reader operates on.
+    data: &'a [u8],
+    /// The offset of the binary reader.
+    pub offset: usize,
+    /// The initial offset of the binary reader.
+    initial_offset: usize,
+}
+
+impl<'a> BinaryReader<'a> {
+    pub fn with_initial_offset(data: &'a [u8], initial_offset: usize) -> Self {
+        Self {
+            data,
+            initial_offset,
+            offset: 0,
+        }
+    }
+
+    /// Returns a reference to the underlying data.
+    pub(crate) fn data(&self) -> &'a [u8] {
+        self.data
+    }
+
+    /// Reads the requested amount of bytes, returning a slice of the bytes.
+    fn read(&mut self, bytes: usize) -> Result<&'a [u8]> {
+        self.ensure(bytes).and_then(|_| {
+            let start = self.offset;
+            self.offset = self.offset + bytes;
+            Ok(&self.data[start..self.offset])
+        })
+    }
+
+    /// Reads a single byte.
+    pub fn read_u8(&mut self) -> Result<u8> {
+        let slice = self.read(1)?;
+        // TODO: Get rid of the `expect`.
+        let byte = slice.first().expect("single byte to be available");
+
+        Ok(*byte)
+    }
+
+    /// Reads two bytes into a `u16`.
+    pub fn read_u16(&mut self) -> Result<u16> {
+        let slice = self.read(2)?;
+        Ok(u16::from_le_bytes(slice.try_into()?))
+    }
+
+    /// Reads 8 bytes into a `u64`.
+    pub fn read_u64(&mut self) -> Result<u64> {
+        let slice = self.read(8)?;
+        Ok(u64::from_le_bytes(slice.try_into()?))
+    }
+
+    /// Reads an integer in LEB-128 format.
+    pub fn read_leb128(&mut self) -> Result<u32> {
+        let mut cursor = Cursor::new(&self.data[self.offset..]);
+        let val = leb128::read::unsigned(&mut cursor)?;
+        let bytes_read = cursor.position();
+
+        self.offset = self.offset + bytes_read as usize;
+
+        Ok(u32::try_from(val)?)
+    }
+
+    /// Reads a signed integer in LEB-128 format.
+    pub fn read_sleb128(&mut self) -> Result<i32> {
+        let mut cursor = Cursor::new(&self.data[self.offset..]);
+        let val = leb128::read::signed(&mut cursor)?;
+        let bytes_read = cursor.position();
+
+        self.offset = self.offset + bytes_read as usize;
+
+        Ok(i32::try_from(val)?)
+    }
+
+    /// Skips the specified number of bytes.
+    pub fn skip(&mut self, bytes: usize) -> Result<()> {
+        self.ensure(bytes).and_then(|_| {
+            self.offset = self.offset + bytes;
+            Ok(())
+        })
+    }
+
+    /// Validates that the underlying data has at least `size` bytes.
+    fn ensure(&self, size: usize) -> Result<()> {
+        let req = self.offset + size;
+        ensure!(
+            req <= self.data.len(),
+            "Tried to read more bytes than available"
+        );
+
+        Ok(())
+    }
+}
+
+/// Creates a [BinaryReader] slice for a bytecode section.
+pub(crate) fn slice<'a>(reader: &mut BinaryReader<'a>, size: usize) -> Result<BinaryReader<'a>> {
+    let data = reader.data();
+    let slice = &data[reader.offset..(reader.offset + size)];
+    let res = BinaryReader::with_initial_offset(slice, reader.offset);
+    reader.skip(size)?;
+    Ok(res)
+}
+
+/// Reads the bytes representing a QuickJS string.
+pub(crate) fn read_str_bytes<'a>(reader: &mut BinaryReader<'a>) -> Result<&'a [u8]> {
+    let mut len = reader.read_leb128()?;
+    // The last bit of the length encodes if the atom is a wide char.
+    let is_wide_char = len & 1;
+    // Once we have read the `wide_char` bit, we clear it out.
+    len >>= 1;
+    let size = (len << is_wide_char) as usize;
+    let res = &reader.data()[reader.offset..(reader.offset + (size as usize))];
+    reader.skip(size)?;
+
+    Ok(res)
+}

--- a/crates/quickpars/src/sections.rs
+++ b/crates/quickpars/src/sections.rs
@@ -1,0 +1,112 @@
+//! Bytecode sections.
+
+use crate::readers::BinaryReader;
+
+/// The start section of the bytecode.
+#[derive(Debug, Copy, Clone)]
+pub struct HeaderSection<'a> {
+    /// The number of interned atoms in the bytecode.
+    pub atom_count: u32,
+    /// The binary reader
+    reader: BinaryReader<'a>,
+}
+
+// TODO
+// Add a way to read the atoms.
+impl<'a> HeaderSection<'a> {
+    /// Creates a new [HeaderSection].
+    pub(crate) fn new(atom_count: u32, reader: BinaryReader<'a>) -> Self {
+        Self { atom_count, reader }
+    }
+}
+#[derive(Debug, Clone, Copy)]
+pub struct ModuleSection<'a> {
+    /// The index of the module name.
+    name_index: u32,
+    /// The binary reader over the module section.
+    reader: BinaryReader<'a>,
+}
+
+impl<'a> ModuleSection<'a> {
+    /// Creates a new [ModuleSection].
+    pub(crate) fn new(name_index: u32, reader: BinaryReader<'a>) -> Self {
+        Self { name_index, reader }
+    }
+}
+
+/// Function section metadata.
+#[derive(Debug, Default, Copy, Clone)]
+pub struct FunctionSectionHeader {
+    /// Function flags.
+    pub flags: u16,
+    /// The index of the function name.
+    pub name_index: u32,
+    /// The argument count.
+    pub arg_count: u32,
+    /// The variable count.
+    pub var_count: u32,
+    /// The defined argument count.
+    pub defined_arg_count: u32,
+    /// The stack size.
+    pub stack_size: u32,
+    /// The closure count.
+    pub closure_count: u32,
+    /// The number of elements in the constant pool.
+    pub constant_pool_size: u32,
+    /// The function bytecode length.
+    pub bytecode_len: u32,
+    /// The number of locals.
+    pub local_count: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DebugInfo<'a> {
+    filename: u32,
+    lineno: u32,
+    reader: BinaryReader<'a>,
+}
+
+impl<'a> DebugInfo<'a> {
+    /// Create a new [DebugInfo].
+    pub fn new(filename: u32, lineno: u32, reader: BinaryReader<'a>) -> Self {
+        Self {
+            filename,
+            lineno,
+            reader,
+        }
+    }
+}
+
+/// A function section.
+#[derive(Debug, Clone, Copy)]
+pub struct FunctionSection<'a> {
+    /// The function section header.
+    pub header: FunctionSectionHeader,
+    /// The locals reader.
+    locals_reader: BinaryReader<'a>,
+    /// The closures reader.
+    closures_reader: BinaryReader<'a>,
+    /// The operators reader.
+    operators_reader: BinaryReader<'a>,
+    /// The function debug information.
+    debug: Option<DebugInfo<'a>>,
+}
+
+impl<'a> FunctionSection<'a> {
+    /// Create a new [FunctionSection].
+    pub(crate) fn new(
+        header: FunctionSectionHeader,
+        locals_reader: BinaryReader<'a>,
+        closures_reader: BinaryReader<'a>,
+        operators_reader: BinaryReader<'a>,
+        debug: Option<DebugInfo<'a>>,
+    ) -> Self {
+        Self {
+            header,
+            locals_reader,
+            closures_reader,
+            operators_reader,
+            debug,
+        }
+    }
+}


### PR DESCRIPTION
This commit is an initial working version of an event driven parser for QuickJS bytecode, heavily inspired by wasm-tool's wasmparser. 

The general idea of this parser is to slice the bytecode into sections, and avoid constructing any intermediate representations eagearly, instead any sections that involve a "collection" of items are returned as-is to the caller via the `Payload`. 