### PR TITLE
Introduce `OperatorsReader`

### DIFF
--- a/crates/jacc/src/lib.rs
+++ b/crates/jacc/src/lib.rs
@@ -19,6 +19,15 @@ use quickpars::{Parser, Payload};
 //   * `JS_ReadObjectRec`
 //   * `JS_ReadFunctionTag` (setup locals, etc)
 //      * `JS_ReadFunctionBytecode` (setup more atoms?)
+//
+// * After having "instantiated" the bytecode. We can evaluate a particular
+// function by:
+//    * using `JS_Eval`, and then `JS_EvalThis` and finally `JS_EvalInternal`,
+//      which ends up in `__JS_EvalInternal`
+//    * Those functions read flags, and sets things up and then
+//    `JS_EvalFunctionInternal` gets evaluated.
+//    * Finally `JS_CallInternal` does the bulk of the work.
+//
 
 // For the compiler to cooperate with the runtime, multiple things need to
 // happen:
@@ -37,7 +46,20 @@ use quickpars::{Parser, Payload};
 /// Main entry point to compile QuickJS bytecode ahead-of-time to WebAssembly.
 pub fn compile(bytes: &[u8]) -> Result<Vec<u8>> {
     for payload in Parser::new().parse_buffer(bytes) {
-        dbg!(payload?);
+        match payload? {
+            f @ Payload::Function(section) => {
+                dbg!(&f);
+                let mut op_reader = section.operators_reader();
+                while !op_reader.done() {
+                    let op = op_reader.read()?;
+                    dbg!(op);
+                }
+            }
+
+            p => {
+                dbg!(p);
+            }
+        }
     }
 
     Ok(vec![])

--- a/crates/quickpars/src/lib.rs
+++ b/crates/quickpars/src/lib.rs
@@ -3,6 +3,7 @@
 use anyhow::{anyhow, Context, Result};
 
 mod bc;
+mod op;
 mod readers;
 mod sections;
 use bc::{flag, validate_version, Tag};
@@ -139,7 +140,7 @@ impl Parser {
             Tag::FunctionBytecode => {
                 let flags = reader.read_u16()?;
                 // JS mode.
-                // Unsure what this is for.
+                // Are we in `strict` mode?.
                 reader.read_u8()?;
                 let name_index = reader.read_leb128()?;
                 let arg_count = reader.read_leb128()?;

--- a/crates/quickpars/src/op.rs
+++ b/crates/quickpars/src/op.rs
@@ -1,0 +1,461 @@
+/// A QuickJS operator code.
+#[derive(Debug)]
+pub enum Opcode {
+    /// A marker, never emitted.
+    Invalid,
+    /// Push an `i32` value.
+    PushI32 {
+        value: i32,
+    },
+    /// Push a constant value.
+    PushConst {
+        /// The index of the constant in the constant pool.
+        index: u32,
+    },
+    /// Push a function closure value.
+    FClosure {
+        /// The index of the closure in the constant pool.
+        index: u32,
+    },
+    /// Push an atom constant.
+    PushAtomValue {
+        /// The immediate value of the atom.
+        val: u32,
+    },
+    /// Push a private symbol from an atom immediate.
+    PrivateSymbol {
+        /// The immediate value of the atom.
+        val: u32,
+    },
+    /// Push undefined value.
+    Undefined,
+    /// Push a null value.
+    Null,
+    /// Push the current object.
+    PushThis,
+    /// Push a false constant.
+    PushFalse,
+    /// Puhs a true constant.
+    PushTrue,
+    /// Push a new object.
+    Object,
+    /// Push a special object.
+    SpecialObject {
+        /// The special object argument.
+        argument: i32,
+    },
+    // TODO: Verify this.
+    /// Rest arguments.
+    Rest {
+        /// The first argument.
+        first: u16,
+    },
+    /// Drop the top value.
+    Drop,
+    /// Drop the second top value.
+    Nip,
+    /// Drop the third top value.
+    Nip1,
+    /// Duplicate the top value, pushing the new value at the stack top.
+    Dup,
+    /// Similar to [Opcode::Dup] but puts the new value in the second top most
+    /// position.
+    Dup1,
+    /// Duplicate the top two values, pushing the new values at the stack top.
+    Dup2,
+    /// Duplicate the top three values pushing the values at the stack top.
+    Dup3,
+
+    // TODO: Skipping comments for now.
+    Insert2,
+    Insert3,
+    Insert4,
+    Perm3,
+    Perm4,
+    Perm5,
+    Swap,
+    Swap2,
+    Rot3L,
+    Rot3R,
+    Rot4L,
+    Rot5L,
+
+    CallConstructor {
+        argc: u16,
+    },
+    Call {
+        argc: u16,
+    },
+    TailCall {
+        argc: u16,
+    },
+    CallMethod {
+        argc: u16,
+    },
+    TailCallMethod {
+        argc: u16,
+    },
+
+    ArrayFrom {
+        argc: u16,
+    },
+    Apply {
+        magic: u16,
+    },
+    Return,
+    ReturnUndef,
+    CheckCtorReturn,
+    CheckCtor,
+    CheckBrand,
+    AddBrand,
+    ReturnAsync,
+    Throw,
+    ThrowError {
+        ty: u8,
+        atom: u32,
+    },
+    Eval {
+        scope: u16,
+        argc: u16,
+    },
+    ApplyEval {
+        scope: u16,
+    },
+    Regexp,
+
+    GetSuper,
+    Import,
+
+    CheckVar {
+        atom: u32,
+    },
+    GetVar {
+        atom: u32,
+    },
+    GetVarUndef {
+        atom: u32,
+    },
+    PutVar {
+        atom: u32,
+    },
+    PutVarInit {
+        atom: u32,
+    },
+    PutVarStrict {
+        atom: u32,
+    },
+    GetRefValue,
+    PutRefValue,
+    DefineVar {
+        flags: u8,
+        atom: u32,
+    },
+    CheckDefineVar {
+        flags: u8,
+        atom: u32,
+    },
+    DefineFunc {
+        flags: u8,
+        atom: u32,
+    },
+    GetField {
+        atom: u32,
+    },
+    GetField2 {
+        atom: u32,
+    },
+    PutField {
+        atom: u32,
+    },
+    GetPrivateField,
+    PutPrivateField,
+    DefinePrivateField,
+    GetArrayEl,
+    GetArrayEl2,
+    PutArrayEl,
+    GetSuperValue,
+    PutSuperValue,
+    DefineField,
+    SetName {
+        atom: u32,
+    },
+    SetNameComputed,
+    SetProto,
+    SetHomeObject,
+    DefineArray,
+    Append,
+    CopyDataProperties {
+        mask: u8,
+    },
+    DefineMethod {
+        atom: u32,
+        flags: u8,
+    },
+    DefineMethodComputed {
+        flags: u8,
+    },
+    DefineClass {
+        flags: u8,
+        atom: u32,
+    },
+    DefineClassComputed {
+        flags: u8,
+        atom: u32,
+    },
+    GetLoc {
+        index: u16,
+    },
+    PutLoc {
+        index: u16,
+    },
+    SetLoc {
+        index: u16,
+    },
+    GetArg {
+        index: u16,
+    },
+    PutArg {
+        index: u16,
+    },
+    SetArg {
+        index: u16,
+    },
+    GetVarRef {
+        index: u16,
+    },
+    PutVarRef {
+        index: u16,
+    },
+    SetVarRef {
+        index: u16,
+    },
+    SetLocUninit {
+        index: u16,
+    },
+    GetLocCheck {
+        index: u16,
+    },
+    PutLocCheck {
+        index: u16,
+    },
+    PutLocCheckInit {
+        index: u16,
+    },
+    GetVarRefCheck {
+        index: u16,
+    },
+    PutVarRefCheck {
+        index: u16,
+    },
+    PutVarRefCheckInit {
+        index: u16,
+    },
+    CloseLoc {
+        index: u16,
+    },
+    IfFalse {
+        offset: u32,
+    },
+    IfTrue {
+        offset: u32,
+    },
+    GoTo {
+        offset: u32,
+    },
+    Catch {
+        diff: u32,
+    },
+    GoSub {
+        diff: u32,
+    },
+    Ret,
+    ToObject,
+    ToPropKey,
+    ToPropKey2,
+    WithGetVar {
+        atom: u32,
+        diff: u32,
+        is_with: u8,
+    },
+    WithPutVar {
+        atom: u32,
+        diff: u32,
+        is_with: u8,
+    },
+    WithDeleteVar {
+        atom: u32,
+        diff: u32,
+        is_with: u8,
+    },
+    WithMakeRef {
+        atom: u32,
+        diff: u32,
+        is_with: u8,
+    },
+    WithGetRef {
+        atom: u32,
+        diff: u32,
+        is_with: u8,
+    },
+    WithGetRefUndef {
+        atom: u32,
+        diff: u32,
+        is_with: u8,
+    },
+    ForInStart,
+    ForOfStart,
+    ForAwaitOfStart,
+    ForInNext,
+    ForOfNext {
+        offset: u8,
+    },
+    IteratorCheckObject,
+    IteratorCheckValueDone,
+    IteratorClose,
+    IteratorCloseReturn,
+    IteratorNext,
+    IteratorCall {
+        flags: u8,
+    },
+    IteratorYield,
+    Yield,
+    YieldStar,
+    AsyncYieldStar,
+    Await,
+    Neg,
+    Plus,
+    Dec,
+    Inc,
+    PostDec,
+    PostInc,
+    DecLoc {
+        index: u8,
+    },
+    IncLoc {
+        index: u8,
+    },
+    AddLoc {
+        index: u8,
+    },
+    Not,
+    LNot,
+    TypeOf,
+    Delete,
+    DeleteVar {
+        atom: u32,
+    },
+    Mul,
+    Div,
+    Mod,
+    Add,
+    Sub,
+    Pow,
+    Shl,
+    Sar,
+    Shr,
+    Lt,
+    Lte,
+    Gt,
+    Gte,
+    InstanceOf,
+    In,
+    Eq,
+    Neq,
+    StrictEq,
+    StrictNeq,
+    And,
+    Xor,
+    Or,
+    UndefOrNull,
+    MulPow10,
+    MathMod,
+    // Short opcodes.
+    PushMinus1,
+    Push0,
+    Push1,
+    Push2,
+    Push3,
+    Push4,
+    Push5,
+    Push6,
+    Push7,
+    PushI8 {
+        val: i8,
+    },
+    PushI16 {
+        val: i16,
+    },
+    PushConst8 {
+        index: u8,
+    },
+    FClosure8 {
+        index: u8,
+    },
+    PushEmptyString,
+    GetLoc8 {
+        index: u8,
+    },
+    PutLoc8 {
+        index: u8,
+    },
+    SetLoc8 {
+        index: u8,
+    },
+    GetLoc0,
+    GetLoc1,
+    GetLoc2,
+    GetLoc3,
+    PutLoc0,
+    PutLoc1,
+    PutLoc2,
+    PutLoc3,
+    SetLoc0,
+    SetLoc1,
+    SetLoc2,
+    SetLoc3,
+    GetArg0,
+    GetArg1,
+    GetArg2,
+    GetArg3,
+    PutArg0,
+    PutArg1,
+    PutArg2,
+    PutArg3,
+    SetArg0,
+    SetArg1,
+    SetArg2,
+    SetArg3,
+    GetVarRef0,
+    GetVarRef1,
+    GetVarRef2,
+    GetVarRef3,
+    PutVarRef0,
+    PutVarRef1,
+    PutVarRef2,
+    PutVarRef3,
+    SetVarRef0,
+    SetVarRef1,
+    SetVarRef2,
+    SetVarRef3,
+    GetLength,
+    IfFalse8 {
+        alternate_offset: u8,
+    },
+    IfTrue8 {
+        offset: u8,
+    },
+    GoTo8 {
+        offset: u8,
+    },
+    GoTo16 {
+        offset: u16,
+    },
+    Call0,
+    Call1,
+    Call2,
+    Call3,
+    IsUndefined,
+    IsNull,
+    TypeOfIsUndefined,
+    TypeOfIsFunction,
+}

--- a/crates/quickpars/src/readers.rs
+++ b/crates/quickpars/src/readers.rs
@@ -52,6 +52,12 @@ impl<'a> BinaryReader<'a> {
         Ok(u16::from_le_bytes(slice.try_into()?))
     }
 
+    /// Reads four bytes into a `u32`.
+    pub fn read_u32(&mut self) -> Result<u32> {
+        let slice = self.read(4)?;
+        Ok(u32::from_le_bytes(slice.try_into()?))
+    }
+
     /// Reads 8 bytes into a `u64`.
     pub fn read_u64(&mut self) -> Result<u64> {
         let slice = self.read(8)?;


### PR DESCRIPTION
This commit is the initial introduction of an `OperatorsReader` for a function section. The reader supports enough opcodes to print-debug the following program:

    console.log("Hello World!");

    function main() {
       return 1 + 1
    }


There's no fundamental reason why it couldn't support other opcodes, it's just enough to experiment for now with other parts of the compilation process.